### PR TITLE
Adds NM membership management scripts

### DIFF
--- a/examples/databases/bulk-edit/changelog.js
+++ b/examples/databases/bulk-edit/changelog.js
@@ -53,5 +53,5 @@ async function editPage(page) {
 (async () => {
   const pages = await fetchAllPages(databaseId);
 
-  performWithAll(pages, editPage);
+  await performWithAll(pages, editPage);
 })();

--- a/examples/databases/bulk-edit/index.js
+++ b/examples/databases/bulk-edit/index.js
@@ -83,5 +83,5 @@ async function editPage(page) {
     },
   });
 
-  performWithAll(pages, editPage);
+  await performWithAll(pages, editPage);
 })();

--- a/examples/nm/align-member-ids.js
+++ b/examples/nm/align-member-ids.js
@@ -1,0 +1,82 @@
+const { notion } = require('../shared');
+const { fetchAllPages, performWithAll } = require('../shared/fetch-pages');
+const { log } = require('../shared/utils');
+const { getCache } = require('./shared');
+
+const studentsDbId = '9d29ced8e9ba467c84e74fabbbbacc01';
+
+async function updateStudent(page, users) {
+  const {
+    properties: {
+      Email: { email },
+    },
+  } = page;
+
+  const user = users.find((m) => {
+    return m['email'] == email;
+  });
+
+  let properties = {
+    Missing: {
+      checkbox: false,
+    },
+  };
+
+  if (user) {
+    properties = {
+      ...properties,
+      NMID: {
+        rich_text: [
+          {
+            text: {
+              content: user['id'],
+            },
+          },
+        ],
+      },
+    };
+  } else {
+    properties.Missing.checkbox = true;
+  }
+
+  // log(page.properties.Name.title[0].plain_text);
+  // log(properties);
+
+  return await notion.pages.update({
+    page_id: page.id,
+    properties,
+  });
+}
+
+(async () => {
+  const users = await getCache('members');
+
+  const pages = await fetchAllPages(studentsDbId, {
+    filter: {
+      and: [
+        {
+          property: 'NMID',
+          rich_text: {
+            is_empty: true,
+          },
+        },
+        {
+          property: 'Status',
+          select: {
+            equals: 'Active',
+          },
+        },
+        {
+          property: 'Missing',
+          checkbox: {
+            equals: false,
+          },
+        },
+      ],
+    },
+  });
+
+  // console.log(pages.length);
+
+  await performWithAll(pages, updateStudent, [users]);
+})();

--- a/examples/nm/align-user-ids.js
+++ b/examples/nm/align-user-ids.js
@@ -1,0 +1,79 @@
+const { notion } = require('../shared');
+const { fetchAllPages, performWithAll } = require('../shared/fetch-pages');
+const { log } = require('../shared/utils');
+const { getCache } = require('./shared');
+
+const studentsDbId = '9d29ced8e9ba467c84e74fabbbbacc01';
+
+async function updateStudent(page, users) {
+  const user = users.find((m) => {
+    return m['OKID'] == page.id.replaceAll('-', '');
+  });
+
+  let properties = {
+    Missing: {
+      checkbox: false,
+    },
+  };
+
+  if (user) {
+    properties = {
+      ...properties,
+      NMID: {
+        rich_text: [
+          {
+            text: {
+              content: user['NMID'],
+            },
+          },
+        ],
+      },
+    };
+  } else {
+    properties.Missing.checkbox = true;
+  }
+
+  // log(page.properties.Name.title[0].plain_text);
+  // log(properties);
+
+  return await notion.pages.update({
+    page_id: page.id,
+    properties,
+  });
+}
+
+(async () => {
+  const data = await getCache('members-nm-groups');
+  const nm = data['nm']['found'];
+  const legacy = data['legacy']['found'];
+  const users = nm.concat(legacy);
+
+  const pages = await fetchAllPages(studentsDbId, {
+    filter: {
+      and: [
+        {
+          property: 'NMID',
+          rich_text: {
+            is_empty: true,
+          },
+        },
+        {
+          property: 'Status',
+          select: {
+            equals: 'Active',
+          },
+        },
+        {
+          property: 'Missing',
+          checkbox: {
+            equals: false,
+          },
+        },
+      ],
+    },
+  });
+
+  // console.log(pages.length);
+
+  await performWithAll(pages, updateStudent, [users]);
+})();

--- a/examples/nm/bulk-member-add-by-email.js
+++ b/examples/nm/bulk-member-add-by-email.js
@@ -1,0 +1,55 @@
+const { RateLimit } = require('async-sema');
+const { RED_COLOR, yargs } = require('../shared/scim');
+const { addMemberToGroup, findMemberByEmail, findOrProvisionUser, getCache } = require('./shared');
+
+const RPS = 3;
+const limit = RateLimit(RPS);
+
+const argv = yargs
+  .option('groupId', {
+    alias: 'g',
+    describe: 'The ID of the group to add the User to',
+    demand: true,
+    default: '7d3e5712-a873-43a8-a4b5-2ab138a9e2ea',
+  })
+  .option('file', {
+    alias: 'f',
+    describe: 'File of user IDs to add to group',
+    demand: true,
+    default: 'members-import',
+  })
+  .boolean('provision')
+  .default({ provision: false }).argv;
+
+async function addMember(groupId, user, provision = false) {
+  await limit();
+
+  const { email } = user;
+
+  let member;
+
+  if (provision) {
+    member = await findOrProvisionUser(email);
+  } else {
+    member = await findMemberByEmail(email);
+
+    if (!member) {
+      console.log(RED_COLOR, `No member by email <${email}> found`);
+      return;
+    }
+  }
+
+  await limit();
+
+  return await addMemberToGroup(groupId, member.id);
+}
+
+(async () => {
+  const users = await getCache(argv.file);
+
+  for (const user of users) {
+    await addMember(argv.groupId, user, argv.provision);
+  }
+
+  console.log(`${users.length} added to group`);
+})();

--- a/examples/nm/bulk-member-add.js
+++ b/examples/nm/bulk-member-add.js
@@ -1,0 +1,33 @@
+const { RateLimit } = require('async-sema');
+const { RED_COLOR } = require('../shared/scim');
+const { addMemberToGroup, getCache } = require('./shared');
+
+const RPS = 1;
+const limit = RateLimit(RPS);
+
+async function addMember(groupId, user) {
+  await limit();
+
+  const { memberName, newEmail, email, NMID } = user;
+
+  console.log(`Added ${memberName} <${newEmail || email}> (${NMID}) to ${groupId}`);
+
+  return await addMemberToGroup(groupId, NMID);
+}
+
+async function addMembers(groupId, cacheName) {
+  const users = await getCache(cacheName);
+
+  console.log(`Adding ${users.length} members to group ${groupId}`);
+
+  for (const user of users) {
+    await addMember(groupId, user);
+  }
+
+  console.log(`${users.length} added to group`);
+}
+
+(async () => {
+  await addMembers('7d3e5712-a873-43a8-a4b5-2ab138a9e2ea', 'members-import-nm');
+  await addMembers('922f01d5-b5e4-4f13-9be7-411242a2c68b', 'members-import-legacy');
+})();

--- a/examples/nm/data/.gitignore
+++ b/examples/nm/data/.gitignore
@@ -1,0 +1,1 @@
+members*

--- a/examples/nm/data/groups.json
+++ b/examples/nm/data/groups.json
@@ -1,0 +1,50 @@
+[
+  {
+    "displayName": "Admin",
+    "id": "a35ee21b-4d22-4082-a33d-2db565a043bd",
+    "memberCount": 3,
+    "index": 8
+  },
+  {
+    "displayName": "Contributors",
+    "id": "4c179c85-96b1-4dd5-8858-a89ae5acc4ca",
+    "memberCount": 2,
+    "index": 2
+  },
+  {
+    "displayName": "Curriculum",
+    "id": "28724504-caac-4f4b-975f-e2c4b1907d06",
+    "memberCount": 3,
+    "index": 1
+  },
+  {
+    "displayName": "Formula Fundamentals 2.0",
+    "id": "70158620-4985-4b86-b08e-95657b6d2edf",
+    "memberCount": 0,
+    "index": 4
+  },
+  {
+    "displayName": "Notion Mastery",
+    "id": "7d3e5712-a873-43a8-a4b5-2ab138a9e2ea",
+    "memberCount": 0,
+    "index": 5
+  },
+  {
+    "displayName": "Notion Mastery Alumni",
+    "id": "922f01d5-b5e4-4f13-9be7-411242a2c68b",
+    "memberCount": 0,
+    "index": 6
+  },
+  {
+    "displayName": "Notion Mastery Members",
+    "id": "9e7b05bc-e9e6-4b7a-8246-f8b1af875ea2",
+    "memberCount": 0,
+    "index": 7
+  },
+  {
+    "displayName": "Team",
+    "id": "6b4b5525-5248-4bee-9d4a-05d5114b58b9",
+    "memberCount": 4,
+    "index": 3
+  }
+]

--- a/examples/nm/data/scim-group-add.json
+++ b/examples/nm/data/scim-group-add.json
@@ -1,0 +1,14 @@
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+  "Operations": [
+    {
+      "op": "Add",
+      "path": "members",
+      "value": [
+        {
+          "value": "8fe75cf9-8a28-484e-aed8-149e8293d5fc"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/nm/data/scim-user-add.json
+++ b/examples/nm/data/scim-user-add.json
@@ -1,0 +1,4 @@
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "userName": "ben+ff2@wareokidoki.com"
+}

--- a/examples/nm/list-groups.js
+++ b/examples/nm/list-groups.js
@@ -1,0 +1,49 @@
+/**
+ * Output a list of all groups in the Notion Mastery workspace.
+ */
+
+const _ = require('lodash');
+const { scim, yargs } = require('../shared/scim');
+const { log } = require('../shared/utils');
+const { setCache } = require('./shared');
+
+(async () => {
+  // GET https://api.notion.com/scim/v2/Groups
+
+  const params = {
+    count: 100,
+    startIndex: 1,
+  };
+
+  try {
+    let {
+      data: { Resources: groups },
+    } = await scim.get('Groups', { params });
+
+    // Formats groups into simple format showing group name, id,
+    // and a count showing the number of members in the group.
+
+    groups = _.reduce(
+      groups,
+      (all, group) => {
+        all.push({
+          displayName: group.displayName,
+          id: group.id,
+          memberCount: group.members.length || 0,
+          index: all.length + 1,
+        });
+
+        return all;
+      },
+      []
+    );
+
+    groups = _.orderBy(groups, 'displayName');
+
+    await setCache('groups', groups);
+
+    log(groups);
+  } catch (e) {
+    console.log(e);
+  }
+})();

--- a/examples/nm/list-legacy.js
+++ b/examples/nm/list-legacy.js
@@ -1,0 +1,37 @@
+/**
+ * Fetch all legacy customers from the "NM Student Database".
+ */
+
+const { RateLimit } = require('async-sema');
+const { fetchAllPages } = require('../shared/fetch-pages');
+const { log } = require('../shared/utils');
+const { setCache } = require('./shared');
+
+const rateLimiter = RateLimit(5);
+
+(async () => {
+  const query = {
+    filter: {
+      and: [
+        {
+          property: 'Lifetime (A)',
+          checkbox: {
+            equals: true,
+          },
+        },
+        {
+          property: 'Status',
+          select: {
+            equals: 'Active',
+          },
+        },
+      ],
+    },
+  };
+
+  const students = await fetchAllPages('9d29ced8e9ba467c84e74fabbbbacc01', query, rateLimiter);
+
+  await setCache('members-legacy', students);
+
+  log(students.length);
+})();

--- a/examples/nm/list-members.js
+++ b/examples/nm/list-members.js
@@ -1,0 +1,70 @@
+/**
+ * Output all Members of the space, regardless of status.
+ */
+
+const _ = require('lodash');
+const { RateLimit } = require('async-sema');
+const { scim, yargs } = require('../shared/scim');
+const { log } = require('../shared/utils');
+const { setCache } = require('./shared');
+
+const PER_PAGE = 100;
+const RPS = 2;
+
+const limit = RateLimit(RPS);
+
+let allUsers = [];
+
+async function fetchUsers(page = 1) {
+  const startIndex = 1 + (page - 1) * PER_PAGE;
+  console.log(`Fetching page ${page} at startIndex ${startIndex}...`);
+
+  const params = {
+    count: PER_PAGE,
+    startIndex,
+  };
+
+  try {
+    let data = await scim.get('Users', { params });
+    let {
+      data: { Resources: users, totalResults },
+    } = data;
+
+    allUsers.push(...users);
+
+    let remaining = totalResults - (startIndex + PER_PAGE - 1);
+    if (remaining > 0) {
+      console.log(`\t${remaining} items remaining to fetch, total is ${allUsers.length}...`);
+
+      await limit();
+      await fetchUsers(page + 1);
+    }
+  } catch (e) {
+    console.log(e);
+  }
+}
+
+(async () => {
+  await fetchUsers();
+
+  allUsers = _.reduce(
+    allUsers,
+    (all, user) => {
+      all.push({
+        active: user.active,
+        displayName: user.displayName,
+        email: _.find(user.emails, { primary: true }).value,
+        emails: user.emails,
+        id: user.id,
+        name: user.name,
+      });
+
+      return all;
+    },
+    []
+  );
+
+  console.log(`${allUsers.length} users fetched.`);
+
+  await setCache('members', allUsers);
+})();

--- a/examples/nm/member-add.js
+++ b/examples/nm/member-add.js
@@ -1,0 +1,43 @@
+/**
+ * Add a new or existing Member to a Group.
+ *
+ * 1. Fetch a Member in Notion Mastery, if they don't exist then,
+ * 2. Provision a new User/Member in Notion Mastery, and then,
+ * 3. Add the User provisioned to the Group determined by --group-id option.
+ */
+
+const { yargs } = require('../shared/scim');
+const { addMemberToGroup, findOrProvisionUser } = require('./shared');
+
+const argv = yargs
+  .option('groupId', {
+    alias: 'g',
+    describe: 'The ID of the group to add the User to',
+    demand: true,
+    default: '7d3e5712-a873-43a8-a4b5-2ab138a9e2ea',
+  })
+  .option('email', {
+    alias: 'e',
+    describe: "User's email address",
+  })
+  .option('userId', {
+    alias: 'u',
+    describe: "User's Notion identifier",
+  }).argv;
+
+(async () => {
+  let userId = argv.userId;
+
+  if (!(userId || argv.email)) {
+    return console.log('Need either a userId or email');
+  } else if (!userId) {
+    const user = await findOrProvisionUser(argv.email);
+    userId = user.id;
+  }
+
+  if (!userId) {
+    return console.log('Could not find or provision user');
+  }
+
+  await addMemberToGroup(argv.groupId, userId);
+})();

--- a/examples/nm/member-remove.js
+++ b/examples/nm/member-remove.js
@@ -1,0 +1,42 @@
+/**
+ * Remove a Member from a Group.
+ *
+ * --group-id: ID of Group to remove from
+ * --user-id:  ID of User to remove
+ */
+
+const { yargs } = require('../shared/scim');
+const { findMemberByEmail, removeMemberFromGroup } = require('./shared');
+
+const argv = yargs
+  .option('groupId', {
+    alias: 'g',
+    describe: 'The ID of the group to add the User to',
+    demand: true,
+    default: '7d3e5712-a873-43a8-a4b5-2ab138a9e2ea',
+  })
+  .option('email', {
+    alias: 'e',
+    describe: "User's email address",
+  })
+  .option('userId', {
+    alias: 'u',
+    describe: "User's Notion identifier",
+  }).argv;
+
+(async () => {
+  let userId = argv.userId;
+
+  if (!(userId || argv.email)) {
+    return console.log('Need either a userId or email');
+  } else if (argv.email) {
+    const user = await findMemberByEmail(argv.email);
+    userId = user.id;
+  }
+
+  if (!userId) {
+    return console.log('Could not find user');
+  }
+
+  await removeMemberFromGroup(argv.groupId, userId);
+})();

--- a/examples/nm/shared.js
+++ b/examples/nm/shared.js
@@ -1,0 +1,133 @@
+const path = require('path');
+const fs = require('fs');
+const { scim, SCIM_SCHEMA_PATCH_OP, SCIM_SCHEMA_USER } = require('../shared/scim');
+
+async function addMemberToGroup(groupId, userId) {
+  // PATCH https://api.notion.com/scim/v2/Groups/{id}
+
+  try {
+    const { status, statusText } = await scim.patch(`Groups/${groupId}`, {
+      schemas: [SCIM_SCHEMA_PATCH_OP],
+      Operations: [
+        {
+          op: 'Add',
+          path: 'members',
+          value: [
+            {
+              value: userId,
+            },
+          ],
+        },
+      ],
+    });
+
+    console.log(`${status}: ${statusText} - ${userId}`);
+  } catch (e) {
+    console.log('Error', e);
+  }
+}
+
+async function removeMemberFromGroup(groupId, userId) {
+  // PATCH https://api.notion.com/scim/v2/Groups/{id}
+
+  try {
+    const { status, statusText } = await scim.patch(`Groups/${groupId}`, {
+      schemas: [SCIM_SCHEMA_PATCH_OP],
+      Operations: [
+        {
+          op: 'Remove',
+          path: 'members',
+          value: [
+            {
+              value: userId,
+            },
+          ],
+        },
+      ],
+    });
+
+    console.log(`${status}: ${statusText} - ${userId}`);
+  } catch (e) {
+    console.log('Error', e);
+  }
+}
+
+async function findMemberByEmail(email) {
+  console.log(`Finding member by email <${email}>`);
+
+  let {
+    data: {
+      Resources: [user],
+    },
+  } = await scim.get('Users', {
+    params: {
+      filter: `email eq "${email}"`,
+      count: 1,
+    },
+  });
+
+  return user;
+}
+
+async function findOrProvisionUser(email) {
+  let user = await findMemberByEmail(email);
+
+  if (!user) {
+    const args = { userName: email };
+
+    // POST https://api.notion.com/scim/v2/Users
+    // Note this will raise a 409 error if user already exists
+    try {
+      const { data } = await scim.post('Users', {
+        schemas: [SCIM_SCHEMA_USER],
+        ...args,
+      });
+
+      user = data;
+    } catch ({ response: { status } }) {
+      console.log(status);
+    }
+  }
+
+  return user;
+}
+
+async function getCache(fileName) {
+  const tmpDir = path.join(__dirname, 'data');
+  const cachePath = path.join(tmpDir, `${fileName}.json`);
+
+  if (fs.existsSync(cachePath)) {
+    return JSON.parse(
+      fs.readFileSync(cachePath, {
+        encoding: 'utf-8',
+        flag: 'r',
+      })
+    );
+  }
+}
+
+async function setCache(fileName, data) {
+  const tmpDir = path.join(__dirname, 'data');
+  const cachePath = path.join(tmpDir, `${fileName}.json`);
+
+  try {
+    if (!fs.existsSync(tmpDir)) {
+      fs.mkdirSync(tmpDir);
+    }
+
+    fs.writeFileSync(cachePath, JSON.stringify(data, null, 2), 'utf-8');
+
+    return data;
+  } catch (error) {
+    console.error(error.toString());
+  }
+}
+
+module.exports = {
+  addMemberToGroup,
+  findMemberByEmail,
+  findOrProvisionUser,
+  removeMemberFromGroup,
+  getCache,
+  setCache,
+};

--- a/examples/nm/split-group-datas.js
+++ b/examples/nm/split-group-datas.js
@@ -1,0 +1,10 @@
+const { getCache, setCache } = require('./shared');
+
+(async () => {
+  const data = await getCache('members-nm-groups');
+  const nm = data['nm']['found'];
+  const legacy = data['legacy']['found'];
+
+  await setCache('members-import-nm', nm);
+  await setCache('members-import-legacy', legacy);
+})();

--- a/examples/nm/user-remove.js
+++ b/examples/nm/user-remove.js
@@ -1,0 +1,43 @@
+/**
+ * DANGER: Completely remove a User from a Workspace!
+ *
+ * NOTE: does not delete Account (manual process)
+ */
+
+const { scim, yargs } = require('../shared/scim');
+const { findMemberByEmail } = require('./shared');
+
+const argv = yargs
+  .option('email', {
+    alias: 'e',
+    describe: "User's email address",
+  })
+  .option('userId', {
+    alias: 'u',
+    describe: "User's Notion identifier",
+  }).argv;
+
+(async function () {
+  let userId = argv.userId;
+
+  if (!(userId || argv.email)) {
+    return console.log('Need either a userId or email');
+  } else if (argv.email) {
+    const user = await findMemberByEmail(argv.email);
+    userId = user.id;
+  }
+
+  if (!userId) {
+    return console.log('Could not find user');
+  }
+
+  // DELETE https://api.notion.com/scim/v2/Users/{id}
+
+  try {
+    const { status, statusText } = await scim.delete(`Users/${userId}`);
+
+    console.log(`${status}: ${statusText} - ${userId}`);
+  } catch ({ response: { status, statusText } }) {
+    console.log(`${status}: ${statusText}`);
+  }
+})();

--- a/examples/shared/fetch-pages.js
+++ b/examples/shared/fetch-pages.js
@@ -7,6 +7,10 @@ const rateLimiter = RateLimit(1, {
 });
 
 async function fetchPages(databaseId, query = null, startCursor = undefined, pageSize = 100) {
+  if (startCursor) {
+    console.log(`Fetching pages starting at ${startCursor}`);
+  }
+
   let params = {
     database_id: databaseId,
     page_size: pageSize,

--- a/examples/shared/scim.js
+++ b/examples/shared/scim.js
@@ -8,6 +8,10 @@ const SCIM_SCHEMA_GROUP = `${SCIM_SCHEMA_BASE}Group`;
 const SCIM_SCHEMA_USER = `${SCIM_SCHEMA_BASE}User`;
 const SCIM_SCHEMA_PATCH_OP = 'urn:ietf:params:scim:api:messages:2.0:PatchOp';
 
+const RED = '\x1b[31m';
+const RESET = '\x1b[0m';
+const RED_COLOR = RED + '%s' + RESET;
+
 dotenv.config();
 
 const auth = yargs.argv.notionScimToken || process.env.NOTION_SCIM_TOKEN;
@@ -20,6 +24,9 @@ const scim = axios.create({
 });
 
 module.exports = {
+  RED,
+  RESET,
+  RED_COLOR,
   SCIM_SCHEMA_GROUP,
   SCIM_SCHEMA_PATCH_OP,
   SCIM_SCHEMA_USER,


### PR DESCRIPTION
- find, provision, and add user to group
- Add a log for fetchPages since Notion API is brutally slow
- Align NM IDs with OKI IDs
- Adds example scim payloads
- Limit data loaded when finding pages that need identifying
- Bulk add members by ID example
- Update student records with member IDs when emails match